### PR TITLE
feat(query): add wildcard '*' query

### DIFF
--- a/moe/core/query.py
+++ b/moe/core/query.py
@@ -53,11 +53,14 @@ To match these special characters as normal, use '/' as an escape character.
 The value can also be a regular expression. To enforce this, use two colons
 e.g. 'field::value.*'
 
-Finally, you can specify any number of terms.
+As a shortcut to matching all entries, use '*' as the term.
+
+Finally, you can also specify any number of terms.
 For example, to match all Wu-Tang Clan tracks that start with the letter 'A', use:
 '"artist:wu-tang clan" title:a%'
 
-Multiple field:value expressions are joined together using AND logic.
+Note that when using multiple terms, they are joined together using AND logic, meaning
+all terms must be true to return a match.
 
 If doing an album query, you still specify track fields, but it will match albums
 instead of tracks.
@@ -96,6 +99,12 @@ def _parse_term(term: str) -> Dict[str, str]:
     Raises:
         ValueError: Invalid query term.
     """
+    # '*' is used as a shortcut to return all entries.
+    # We use track_num as all tracks are guaranteed to have a track number.
+    # '%' is an SQL LIKE query special character.
+    if term == "*":
+        return {FIELD_GROUP: "track_num", SEPARATOR_GROUP: ":", VALUE_GROUP: "%"}
+
     query_re = re.compile(
         rf"""
         (?P<{FIELD_GROUP}>\S+?)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,6 +57,8 @@ def mock_track_factory() -> Callable[[], Track]:
     Note:
         Each track will share the same album attributes, and thus will
         belong to the same album if a mock_track already exists in the database.
+        If adding multiple tracks of the same album in one session, use
+        `session.merge(track)` vice `session.add(track)`
 
     Returns:
         Unique Track object with each call.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -209,3 +209,13 @@ class TestQuery:
 
         assert query.query("'genre:hip hop'", tmp_session)
         assert query.query("genre:rock", tmp_session)
+
+    def test_wildcard_query(self, tmp_session, mock_track_factory):
+        """'*' as a query should return all items."""
+        track1 = mock_track_factory()
+        track2 = mock_track_factory()
+
+        tmp_session.merge(track1)
+        tmp_session.merge(track2)
+
+        assert len(query.query("*", tmp_session)) == 2


### PR DESCRIPTION
Using * as the query term presents a shortcut for the user to match all items in the library.