### PR TITLE
refactor(config): make config a global instance

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -18,7 +18,7 @@ of env.py for different use cases.
 from logging.config import fileConfig
 
 from alembic import context
-from moe.core.config import Config
+from moe.core.config import _Config
 from moe.core.library.session import Base
 
 # this is the Alembic Config object, which provides
@@ -47,8 +47,8 @@ def run_migrations_online():
     In this scenario we need to create an Engine and associate a connection
     with the context.
     """
-    moe_config = Config()
-    moe_config.init_db()
+    moe_config = _Config()
+    moe_config._init_db()
     engine = moe_config.engine
 
     with engine.connect() as connection:

--- a/moe/plugins/add.py
+++ b/moe/plugins/add.py
@@ -9,7 +9,7 @@ import mediafile
 from sqlalchemy.orm.session import Session
 
 import moe
-from moe.core.config import Config
+from moe.core.config import config
 from moe.core.library.album import Album
 from moe.core.library.music_item import MusicItem
 from moe.core.library.session import DbDupTrackPathError
@@ -35,6 +35,9 @@ class Hooks:
         """Provides the MusicItem that was added to the library."""
 
 
+config.pluginmanager.add_hookspecs(Hooks)
+
+
 @moe.hookimpl
 def addcommand(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     """Adds a new `add` command to moe."""
@@ -47,19 +50,16 @@ def addcommand(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     add_parser.set_defaults(func=parse_args)
 
 
-def parse_args(config: Config, session: Session, args: argparse.Namespace):
+def parse_args(session: Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
-        config: Configuration in use.
         session: Current session.
         args: Commandline arguments to parse.
 
     Raises:
         SystemExit: Path given does not exist.
     """
-    config.pluginmanager.add_hookspecs(Hooks)
-
     paths = [pathlib.Path(arg_path) for arg_path in args.paths]
 
     error_count = 0

--- a/moe/plugins/info.py
+++ b/moe/plugins/info.py
@@ -10,7 +10,6 @@ import sqlalchemy
 
 import moe
 from moe.core import query
-from moe.core.config import Config
 from moe.core.library.music_item import MusicItem
 
 
@@ -26,13 +25,10 @@ def addcommand(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     add_parser.set_defaults(func=parse_args)
 
 
-def parse_args(
-    config: Config, session: sqlalchemy.orm.session.Session, args: argparse.Namespace
-):
+def parse_args(session: sqlalchemy.orm.session.Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
-        config: Configuration in use.
         session: Current session.
         args: Commandline arguments to parse.
 

--- a/moe/plugins/ls.py
+++ b/moe/plugins/ls.py
@@ -6,7 +6,6 @@ import sqlalchemy
 
 import moe
 from moe.core import query
-from moe.core.config import Config
 
 
 @moe.hookimpl
@@ -26,13 +25,10 @@ def addcommand(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     add_parser.set_defaults(func=parse_args)
 
 
-def parse_args(
-    config: Config, session: sqlalchemy.orm.session.Session, args: argparse.Namespace
-):
+def parse_args(session: sqlalchemy.orm.session.Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
-        config: Configuration in use.
         session: Current session.
         args: Commandline arguments to parse.
 

--- a/moe/plugins/rm.py
+++ b/moe/plugins/rm.py
@@ -7,7 +7,6 @@ import sqlalchemy
 
 import moe
 from moe.core import query
-from moe.core.config import Config
 
 log = logging.getLogger(__name__)
 
@@ -29,13 +28,10 @@ def addcommand(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     add_parser.set_defaults(func=parse_args)
 
 
-def parse_args(
-    config: Config, session: sqlalchemy.orm.session.Session, args: argparse.Namespace
-):
+def parse_args(session: sqlalchemy.orm.session.Session, args: argparse.Namespace):
     """Parses the given commandline arguments.
 
     Args:
-        config: Configuration in use.
         session: Current session.
         args: Commandline arguments to parse.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,9 @@ ignore =
     WPS602,  # prohibit use of static methods
 per-file-ignores =
    # E800: config file has commented out code as examples
-   alembic/env.py:E800
+   # WPS437: alembic can use protected attributes
+   # WPS450: alembic can import protected objects
+   alembic/env.py:E800,WPS437,WPS450
    # D1: database migrations don't need docstrings
    # I: isort errors tend to misinterpret alembic as a local package
    # WPS102: module/file names aren't standard
@@ -46,8 +48,9 @@ per-file-ignores =
    # WPS437: allow testing of protected attributes/functions
    # WPS441: it's common to test error exit codes out of scope of their context
    # WPS442: pytest has fixture inheritance--leads to arg shadow false-positives
+   # WPS450: tests can import protected items
    # WPS609: mocks can override magic methods
-   tests/*:DAR101,S101,S311,WPS2,WPS432,WPS437,WPS441,WPS442,WPS609
+   tests/*:DAR101,S101,S311,WPS2,WPS432,WPS437,WPS441,WPS442,WPS450,WPS609
    # WPS412: our package init needs to setup the pluggy hooks
    moe/__init__.py:WPS412
    # WPS201: dealing with sqlalchemy results in lots of imports

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import sqlalchemy
 from sqlalchemy.orm.session import Session
 
-from moe.core.config import Config
+from moe.core.config import _Config
 from moe.core.library.session import session_scope
 from moe.core.library.track import Track
 
@@ -22,17 +22,15 @@ def tmp_session() -> Iterator[Session]:
     Yields:
         session: temp Session instance
     """
-    engine = sqlalchemy.create_engine("sqlite:///:memory:")
-
-    config = Config(config_dir=MagicMock())
-    config.init_db(engine=engine)
+    config = _Config(config_dir=MagicMock())
+    config._init_db(engine=sqlalchemy.create_engine("sqlite:///:memory:"))
 
     with session_scope() as session:
         yield session
 
 
 @pytest.fixture
-def tmp_config(tmp_path) -> Config:
+def tmp_config(tmp_path) -> _Config:
     """Instantiates a temporary configuration.
 
     This is for use with integration tests.
@@ -40,12 +38,7 @@ def tmp_config(tmp_path) -> Config:
     Returns:
         The configuration instance.
     """
-    config = Config(config_dir=tmp_path)
-
-    config_file = config.config_dir / "config.toml"
-    config_file.touch()
-
-    return config
+    return _Config(config_dir=tmp_path)
 
 
 @pytest.fixture

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -21,7 +21,7 @@ class TestParseArgs:
         args = argparse.Namespace(paths=["does not exist"])
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), Mock(), args)
+            add.parse_args(Mock(), args)
 
         assert error.value.code != 0
 
@@ -37,7 +37,7 @@ class TestParseArgsDirectory:
         album = "tests/resources/album"
         args = argparse.Namespace(paths=[album])
 
-        add.parse_args(Mock(), tmp_session, args)
+        add.parse_args(tmp_session, args)
 
         assert tmp_session.query(Album).scalar()
 
@@ -48,7 +48,7 @@ class TestParseArgsDirectory:
         args = argparse.Namespace(paths=[album])
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), tmp_session, args)
+            add.parse_args(tmp_session, args)
 
         assert error.value.code != 0
         assert not tmp_session.query(Album).scalar()
@@ -65,7 +65,7 @@ class TestParseArgsDirectory:
         args = argparse.Namespace(paths=[tmp_album_path])
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), tmp_session, args)
+            add.parse_args(tmp_session, args)
 
         assert error.value.code != 0
         assert not tmp_session.query(Album).scalar()
@@ -77,7 +77,7 @@ class TestParseArgsDirectory:
         tmp_session.commit()
         args = argparse.Namespace(paths=[album])
 
-        add.parse_args(Mock(), tmp_session, args)
+        add.parse_args(tmp_session, args)
 
         assert tmp_session.query(Album).scalar()
 
@@ -90,7 +90,7 @@ class TestParseArgsDirectory:
         tmp_session.commit()
         args = argparse.Namespace(paths=[album])
 
-        add.parse_args(Mock(), tmp_session, args)
+        add.parse_args(tmp_session, args)
 
         assert tmp_session.query(Album).scalar()
 
@@ -106,7 +106,7 @@ class TestParseArgsFile:
         file1 = "tests/resources/album/01.mp3"
         args = argparse.Namespace(paths=[file1])
 
-        add.parse_args(Mock(), tmp_session, args)
+        add.parse_args(tmp_session, args)
 
         assert (
             tmp_session.query(Track.path)
@@ -120,7 +120,7 @@ class TestParseArgsFile:
         file2 = "tests/resources/album/02.mp3"
         args = argparse.Namespace(paths=[file1, file2])
 
-        add.parse_args(Mock(), Mock(), args)
+        add.parse_args(Mock(), args)
 
         assert (
             tmp_session.query(Track.path)
@@ -143,7 +143,7 @@ class TestParseArgsFile:
         args = argparse.Namespace(paths=[file1, file2])
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), tmp_session, args)
+            add.parse_args(tmp_session, args)
 
         assert error.value.code != 0
         assert (
@@ -157,7 +157,7 @@ class TestParseArgsFile:
         args = argparse.Namespace(paths=["tests/resources/album/log.txt"])
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), tmp_session, args)
+            add.parse_args(tmp_session, args)
 
         assert error.value.code != 0
 
@@ -166,7 +166,7 @@ class TestParseArgsFile:
         args = argparse.Namespace(paths=["tests/resources/audio_files/empty.mp3"])
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), tmp_session, args)
+            add.parse_args(tmp_session, args)
 
         assert error.value.code != 0
 
@@ -181,7 +181,7 @@ class TestParseArgsFile:
         tmp_session.commit()
 
         with pytest.raises(SystemExit) as error:
-            add.parse_args(Mock(), tmp_session, args)
+            add.parse_args(tmp_session, args)
 
         assert error.value.code != 0
 
@@ -195,8 +195,19 @@ class TestCommand:
         args = ["moe", "add", "tests/resources/audio_files/full.mp3"]
 
         with patch("sys.argv", args):
-            with patch("moe.cli.Config", return_value=tmp_config):
+            with patch("moe.cli.config", tmp_config):
                 cli.main()
 
         with session_scope() as session:
             assert session.query(Track).scalar()
+
+    def test_dir(self, tmp_config):
+        """Albums are added to the library when a dir is passed to `add`."""
+        args = ["moe", "add", "tests/resources/album/"]
+
+        with patch("sys.argv", args):
+            with patch("moe.cli.config", tmp_config):
+                cli.main()
+
+        with session_scope() as session:
+            assert session.query(Album).scalar()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,5 @@
 """Test the CLI."""
 
-from unittest.mock import Mock
-
 import pytest
 
 from moe import cli
@@ -13,6 +11,6 @@ class TestArgParse:
     def test_no_args(self):
         """Test exit if 0 subcommands given."""
         with pytest.raises(SystemExit) as error:
-            cli._parse_args([], Mock())
+            cli._parse_args([])
 
         assert error.value.code != 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 """Test configuration."""
 
-from moe.core.config import Config
+from moe.core.config import _Config
 
 
 class TestInit:
@@ -8,7 +8,7 @@ class TestInit:
 
     def test_config_dir_dne(self, tmp_path):
         """Should create the config directory if it doesn't exist."""
-        config = Config(tmp_path / "doesn't exist")
+        config = _Config(tmp_path / "doesn't exist")
 
         assert config.config_dir.is_dir()
 
@@ -18,6 +18,7 @@ class TestReadConfig:
 
     def test_config_file_dne(self, tmp_path):
         """Should create an empty config file if it doesn't exist."""
-        config = Config(config_dir=tmp_path)
+        config = _Config(config_dir=tmp_path)
+        config._read_config()
 
         assert (config.config_dir / "config.toml").is_file()

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -3,7 +3,7 @@
 import argparse
 import pathlib
 import re
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -23,7 +23,7 @@ class TestParseArgs:
         mock_track.albumartist = "test"
         tmp_session.add(mock_track)
 
-        info.parse_args(Mock(), tmp_session, args)
+        info.parse_args(tmp_session, args)
 
         captured_text = capsys.readouterr()
 
@@ -36,7 +36,7 @@ class TestParseArgs:
 
         tmp_session.add(mock_track)
 
-        info.parse_args(Mock(), tmp_session, args)
+        info.parse_args(tmp_session, args)
 
         captured_text = capsys.readouterr()
 
@@ -47,7 +47,7 @@ class TestParseArgs:
         args = argparse.Namespace(query="bad", album=False)
 
         with pytest.raises(SystemExit) as error:
-            info.parse_args(Mock(), tmp_session, args)
+            info.parse_args(tmp_session, args)
 
         assert error.value.code != 0
 
@@ -97,12 +97,12 @@ class TestCommand:
         )
         args = ["moe", "info", "track_num:1"]
 
-        tmp_config.init_db()
+        tmp_config._init_db()
         with session_scope() as session:
             session.add(track)
 
         with patch("sys.argv", args):
-            with patch("moe.cli.Config", return_value=tmp_config):
+            with patch("moe.cli.config", tmp_config):
                 cli.main()
 
         assert capsys.readouterr().out

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -2,7 +2,7 @@
 
 import argparse
 import pathlib
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -20,7 +20,7 @@ class TestParseArgs:
         args = argparse.Namespace(query=f"title:{mock_track.title}", album=False)
         tmp_session.add(mock_track)
 
-        ls.parse_args(Mock(), tmp_session, args)
+        ls.parse_args(tmp_session, args)
 
         captured_text = capsys.readouterr()
 
@@ -31,7 +31,7 @@ class TestParseArgs:
         args = argparse.Namespace(query=f"title:{mock_track.title}", album=True)
         tmp_session.add(mock_track)
 
-        ls.parse_args(Mock(), tmp_session, args)
+        ls.parse_args(tmp_session, args)
 
         captured_text = capsys.readouterr()
 
@@ -42,7 +42,7 @@ class TestParseArgs:
         args = argparse.Namespace(query="bad", album=False)
 
         with pytest.raises(SystemExit) as error:
-            ls.parse_args(Mock(), tmp_session, args)
+            ls.parse_args(tmp_session, args)
 
         assert error.value.code != 0
 
@@ -62,12 +62,12 @@ class TestCommand:
         )
         args = ["moe", "ls", "track_num:1"]
 
-        tmp_config.init_db()
+        tmp_config._init_db()
         with session_scope() as session:
             session.add(track)
 
         with patch("sys.argv", args):
-            with patch("moe.cli.Config", return_value=tmp_config):
+            with patch("moe.cli.config", tmp_config):
                 cli.main()
 
         assert capsys.readouterr().out

--- a/tests/test_rm.py
+++ b/tests/test_rm.py
@@ -2,7 +2,7 @@
 
 import argparse
 import pathlib
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -23,7 +23,7 @@ class TestParseArgs:
         )
         tmp_session.add(mock_track)
 
-        rm.parse_args(Mock(), tmp_session, args)
+        rm.parse_args(tmp_session, args)
 
         query = tmp_session.query(Track.path).scalar()
 
@@ -34,7 +34,7 @@ class TestParseArgs:
         args = argparse.Namespace(query=f"title:{mock_track.title}", album=True)
         tmp_session.add(mock_track)
 
-        rm.parse_args(Mock(), tmp_session, args)
+        rm.parse_args(tmp_session, args)
 
         query = tmp_session.query(Album).scalar()
 
@@ -45,7 +45,7 @@ class TestParseArgs:
         args = argparse.Namespace(query=f"title:{mock_track.title}", album=True)
         tmp_session.add(mock_track)
 
-        rm.parse_args(Mock(), tmp_session, args)
+        rm.parse_args(tmp_session, args)
 
         query = tmp_session.query(Track).scalar()
 
@@ -56,7 +56,7 @@ class TestParseArgs:
         args = argparse.Namespace(query="bad", album=False)
 
         with pytest.raises(SystemExit) as error:
-            rm.parse_args(Mock(), tmp_session, args)
+            rm.parse_args(tmp_session, args)
 
         assert error.value.code != 0
 
@@ -76,12 +76,12 @@ class TestCommand:
         )
         args = ["moe", "rm", "track_num:1"]
 
-        tmp_config.init_db()
+        tmp_config._init_db()
         with session_scope() as session:
             session.add(track)
 
         with patch("sys.argv", args):
-            with patch("moe.cli.Config", return_value=tmp_config):
+            with patch("moe.cli.config", tmp_config):
                 cli.main()
 
         with session_scope() as session2:


### PR DESCRIPTION
Allows us to easily access moe's config on a case-by-casis, and removes the need to annoyingly pass it to each plugin via hooks.