### PR TITLE
ci(ci): don't run ci for tag commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags-ignore:
+      - v*
   pull_request:
 
 jobs:


### PR DESCRIPTION
No reason to run full CI suite if the commit is just an auto-generated version/changelog & tag update.