### PR TITLE
ci(ci): only run code coverage once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,20 +50,29 @@ jobs:
           python -m pip install --upgrade pip poetry
           poetry install
 
+      - name: Run tests
+        if: ${{ matrix.platform != "ubuntu-latest" || matrix.python-version != 3.8 }}
+        run: |
+          poetry run pytest
+
       - name: Run unit tests and create coverage report
+        if: ${{ matrix.platform == "ubuntu-latest" && matrix.python-version == 3.8 }}
         run: |
           poetry run pytest -v -m "not integration" --cov=. --cov-report=xml
 
       - name: Upload unit test coverage report
+        if: ${{ matrix.platform == "ubuntu-latest" && matrix.python-version == 3.8 }}
         uses: codecov/codecov-action@v1
         with:
           flags: unit
 
       - name: Run integration tests and create coverage report
+        if: ${{ matrix.platform == "ubuntu-latest" && matrix.python-version == 3.8 }}
         run: |
           poetry run pytest -v -m integration --cov=. --cov-report=xml
 
       - name: Upload integration test coverage report
+        if: ${{ matrix.platform == "ubuntu-latest" && matrix.python-version == 3.8 }}
         uses: codecov/codecov-action@v1
         with:
           flags: integration


### PR DESCRIPTION
Should help prevent getting api limited by codecov.