### PR TITLE
refactor(library): convert library sets to lists

### DIFF
--- a/moe/core/library/album.py
+++ b/moe/core/library/album.py
@@ -1,7 +1,7 @@
 """An Album in the database and any related logic."""
 
 import pathlib
-from typing import TYPE_CHECKING, Set, TypeVar
+from typing import TYPE_CHECKING, List, TypeVar
 
 from sqlalchemy import Column, Integer, String  # noqa: WPS458
 from sqlalchemy.orm import relationship
@@ -25,10 +25,10 @@ class Album(LibItem, Base):
 
     Attributes:
         artist (str): AKA albumartist.
-        extras (Set(Extra)): Extra non-track files associated with the album.
+        extras (List[Extra]): Extra non-track files associated with the album.
         path (pathlib.Path): Filesystem path of the album directory.
         title (str)
-        tracks (Set[Track]): Album's corresponding tracks.
+        tracks (List[Track]): Album's corresponding tracks.
         year (str)
     """
 
@@ -45,14 +45,14 @@ class Album(LibItem, Base):
         "Track",
         back_populates="album_obj",
         cascade="all, delete-orphan",
-        collection_class=set,
-    )  # type: Set[Track] # noqa: WPS400
+        collection_class=list,
+    )  # type: List[Track] # noqa: WPS400
     extras = relationship(
         "Extra",
         back_populates="album",
         cascade="all, delete-orphan",
-        collection_class=set,
-    )  # type: Set[Extra] # noqa: WPS400
+        collection_class=list,
+    )  # type: List[Extra] # noqa: WPS400
 
     def __init__(
         self,
@@ -77,6 +77,14 @@ class Album(LibItem, Base):
         self.year = year
         self.path = path
 
+    def has_eq_keys(self, other: "Album") -> bool:
+        """Compares an Album by its primary keys."""
+        return (
+            self.artist == other.artist
+            and self.title == other.title
+            and self.year == other.year
+        )
+
     def __str__(self):
         """String representation of an Album."""
         return f"{self.artist} - {self.title} ({self.year})"
@@ -92,11 +100,13 @@ class Album(LibItem, Base):
         )
 
     def __eq__(self, other):
-        """Compares an Album using its primary keys."""
+        """Compares an Album by it's attributes."""
         if isinstance(other, Album):
             return (
-                self.artist == other.artist
+                self.artist == other.artist  # noqa: WPS222
                 and self.title == other.title
                 and self.year == other.year
+                and self.tracks == other.tracks
+                and self.extras == other.extras
             )
         return False

--- a/moe/core/library/extra.py
+++ b/moe/core/library/extra.py
@@ -22,7 +22,7 @@ else:
     )
 
 
-class Extra(LibItem, Base):
+class Extra(LibItem, Base):  # noqa: WPS214
     """An Album can have any number of extra files such as logs, cues, etc.
 
     Attributes:
@@ -95,3 +95,14 @@ class Extra(LibItem, Base):
             f"{self.__class__.__name__}("
             f"{repr(self.album)}, filename={repr(self._filename)})"
         )
+
+    def __eq__(self, other):
+        """Compares an Extra by it's attributes."""
+        if isinstance(other, Extra):
+            return (
+                self.album.artist == other.album.artist
+                and self.album.title == other.album.title
+                and self.album.year == other.album.year
+                and self.filename == other.filename
+            )
+        return False

--- a/moe/core/library/track.py
+++ b/moe/core/library/track.py
@@ -2,7 +2,7 @@
 
 import logging
 import pathlib
-from typing import List, Set, Type, TypeVar
+from typing import List, Type, TypeVar
 
 import mediafile
 from sqlalchemy import Column, Integer, String  # noqa: WPS458
@@ -51,7 +51,7 @@ class Track(LibItem, Base):  # noqa: WPS230, WPS214
         album_path (pathlib.Path): Path of the album directory.
         artist (str)
         file_ext (str): Audio format extension e.g. mp3, flac, wav, etc.
-        genre (Set[str])
+        genre (List[str])
         path (pathlib.Path): Filesystem path of the track file.
         title (str)
         track_num (int)
@@ -81,11 +81,11 @@ class Track(LibItem, Base):  # noqa: WPS230, WPS214
     album_path: pathlib.Path = association_proxy("album_obj", "path")
     albumartist: str = association_proxy("album_obj", "artist")
     year: int = association_proxy("album_obj", "year")
-    genre: Set[str] = association_proxy("_genre_obj", "name")
+    genre: List[str] = association_proxy("_genre_obj", "name")
 
     album_obj: Album = relationship("Album", back_populates="tracks")
     _genre_obj: _Genre = relationship(
-        "_Genre", secondary=track_genres, collection_class=set
+        "_Genre", secondary=track_genres, collection_class=list
     )
     __table_args__ = (
         ForeignKeyConstraint(
@@ -184,3 +184,19 @@ class Track(LibItem, Base):  # noqa: WPS230, WPS214
             f"track_num={repr(self.track_num)}, "
             f"path={repr(self.path)})"
         )
+
+    def __eq__(self, other):
+        """Compares a Track by it's attributes."""
+        if isinstance(other, Track):
+            return (
+                self.album_obj.artist == other.album_obj.artist  # noqa: WPS222
+                and self.album_obj.title == other.album_obj.title
+                and self.album_obj.year == other.album_obj.year
+                and self.artist == other.artist
+                and self.file_ext == other.file_ext
+                and set(self.genre) == set(other.genre)
+                and self.path == other.path
+                and self.title == other.title
+                and self.track_num == other.track_num
+            )
+        return False

--- a/moe/plugins/edit.py
+++ b/moe/plugins/edit.py
@@ -103,7 +103,7 @@ def _edit_item(item: LibItem, term: str):
     elif isinstance(attr, int):
         setattr(item, field, int(value))
     elif isinstance(
-        attr, sqlalchemy.ext.associationproxy._AssociationSet  # noqa: WPS437
+        attr, sqlalchemy.ext.associationproxy._AssociationList  # noqa: WPS437
     ):
-        set_value = {lv.strip() for lv in value.split(";")}
-        setattr(item, field, set_value)
+        list_value = [lv.strip() for lv in value.split(";")]
+        setattr(item, field, list_value)

--- a/moe/plugins/info.py
+++ b/moe/plugins/info.py
@@ -113,17 +113,16 @@ def _album_dict(album: Album) -> "OrderedDict[str, Any]":
         It will be in the form { attribute: value } and is sorted by attribute.
     """
     # access any element to set intial values
-    track_list = list(album.tracks)  # easier to deal with a list for this func
-    album_dict = _track_extra_dict(track_list[0])
+    album_dict = _track_extra_dict(album.tracks[0])
 
     # compare rest of album against initial values
-    for track in track_list[1:]:
+    for track in album.tracks[1:]:
         track_dict = _track_extra_dict(track)
         for key in {**track_dict, **album_dict}.keys():
             if album_dict.get(key) != track_dict.get(key):
                 album_dict[key] = "Various"
 
-    album_dict["extras"] = {str(extra.path) for extra in album.extras}
+    album_dict["extras"] = [str(extra.path) for extra in album.extras]
 
     # remove values that are always unique between tracks
     album_dict.pop("path")

--- a/moe/plugins/move.py
+++ b/moe/plugins/move.py
@@ -74,7 +74,7 @@ def _copy_item(item: LibItem, album_dir: pathlib.Path):
 
 def _create_album_dir(config: Config, album: Album) -> pathlib.Path:
     """Creates and formats an Album directory."""
-    album_track = list(album.tracks)[0]
+    album_track = album.tracks[0]
 
     album_dir_fmt = "{albumartist}/{album} ({year})"  # noqa; FS003
     library_path = pathlib.Path(config.settings.move.library_path).expanduser()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,11 +114,11 @@ def mock_album_factory(mock_track_factory) -> Callable[[], Album]:
         track = mock_track_factory(year=year)
 
         album = track.album_obj
-        album.tracks.add(mock_track_factory(year=year))
+        album.tracks.append(mock_track_factory(year=year))
 
         mock_log_file = album.path / "log.txt"
         type(mock_log_file).name = PropertyMock(return_value="log.txt")
-        album.extras.add(Extra(mock_log_file, album))
+        album.extras.append(Extra(mock_log_file, album))
 
         return album
 
@@ -210,11 +210,11 @@ def real_album_factory(real_track_factory) -> Callable[[], Album]:
         track = real_track_factory(year=year)
 
         album = track.album_obj
-        album.tracks.add(real_track_factory(album_dir=album.path, year=year))
+        album.tracks.append(real_track_factory(album_dir=album.path, year=year))
 
         log_file = album.path / "log.txt"
         log_file.touch()
-        album.extras.add(Extra(log_file, album))
+        Extra(log_file, album)
 
         return album
 

--- a/tests/library/test_album.py
+++ b/tests/library/test_album.py
@@ -5,28 +5,6 @@ import pytest
 from moe.core.library.session import DbDupAlbumError, DbDupAlbumPathError, session_scope
 
 
-class TestEquals:
-    """Equality based on primary key."""
-
-    def test_equals(self, mock_album_factory):
-        """Equal if two albums share the same primary key attributes."""
-        album1 = mock_album_factory()
-        album2 = mock_album_factory()
-
-        album1.artist = album2.artist
-        album1.title = album2.title
-        album1.year = album2.year
-
-        assert album1 == album2
-
-    def test_not_equals(self, mock_album_factory):
-        """Not equal if two albums don't share the same primary key attributes."""
-        album1 = mock_album_factory()
-        album2 = mock_album_factory()
-
-        assert album1 != album2
-
-
 class TestDuplicate:
     """Test behavior when there is an attempt to add a duplicate Album to the db.
 

--- a/tests/library/test_track.py
+++ b/tests/library/test_track.py
@@ -38,7 +38,7 @@ class TestInit:
             assert track in album.tracks
 
         assert len(tracks) == len(album.tracks)
-        assert set(tracks) == album.tracks
+        assert tracks == album.tracks
 
 
 class TestAlbumSet:
@@ -71,7 +71,7 @@ class TestFromTags:
         assert track.albumartist == "Wu-Tang Clan"
         assert track.artist == "Wu-Tang Clan"
         assert track.file_ext == "mp3"
-        assert track.genre == {"hip hop", "rock"}
+        assert set(track.genre) == {"hip hop", "rock"}
         assert track.title == "Full"
         assert track.track_num == 1
         assert track.year == 2020

--- a/tests/test_add.py
+++ b/tests/test_add.py
@@ -101,7 +101,7 @@ class TestParseArgsDirectory:
 
     def test_duplicate_tracks(self, real_album, tmp_session):
         """Don't fail album add if a track (by tags) already exists in the library."""
-        tmp_session.merge(list(real_album.tracks)[0])
+        tmp_session.merge(real_album.tracks[0])
         tmp_session.commit()
         args = argparse.Namespace(paths=[real_album.path])
 

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -97,7 +97,7 @@ class TestParseArgs:
 
             mock_query.assert_called_once_with("", mock_session, query_type="track")
 
-        assert mock_track.genre == {"a", "b"}
+        assert mock_track.genre == ["a", "b"]
 
     def test_multiple_items(self, mock_track_factory):
         """All items returned from a query are edited."""

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -29,7 +29,7 @@ class TestWriteTags:
         assert new_track.album == "Bigger, Better, Faster, More!"
         assert new_track.albumartist == "4 Non Blondes"
         assert new_track.artist == "4 Non Blondes"
-        assert new_track.genre == {"alternative", "rock"}
+        assert set(new_track.genre) == {"alternative", "rock"}
         assert new_track.title == "What's Up"
         assert new_track.track_num == 3
         assert new_track.year == 1992


### PR DESCRIPTION
Although we want our lists of library items to only contain unique items, it requires each item to be hashable. By definition of mutability, our library item objects are not hashable and thus would be better served being stored in lists.