### PR TITLE
fix(add): track file types now transferred when adding a new album vi…

### DIFF
--- a/moe/plugins/add/prompt.py
+++ b/moe/plugins/add/prompt.py
@@ -211,6 +211,7 @@ def _apply_changes(
             new_track.album_obj = None  # type: ignore # (causes mypy error)
         elif new_track:
             new_track.path = old_track.path
+            new_track.file_ext = old_track.file_ext
 
     for extra in old_album.extras:
         extra.album = new_album

--- a/tests/test_add/test_prompt.py
+++ b/tests/test_add/test_prompt.py
@@ -45,8 +45,10 @@ class TestRunPrompt:
         assert add_album.path == mock_album.path
 
         assert add_album.tracks
-        for track in add_album.tracks:
-            assert track.path == mock_album.get_track(track.track_num).path
+        for added_track in add_album.tracks:
+            old_track = mock_album.get_track(added_track.track_num)
+            assert added_track.file_ext == old_track.file_ext
+            assert added_track.path == old_track.path
 
         assert add_album.extras
 


### PR DESCRIPTION
…a prompt

Track file extensions (types) were not being transferred when applying changes to an album via the add prompt.