### PR TITLE
refactor(add): abstract questionary dependency from API

### DIFF
--- a/docs/developers/api/moe.plugins.rst
+++ b/docs/developers/api/moe.plugins.rst
@@ -10,6 +10,7 @@ Add
    :members:
    :undoc-members:
    :show-inheritance:
+   :noindex:
 
 Edit
 ----

--- a/moe/plugins/add/hooks.py
+++ b/moe/plugins/add/hooks.py
@@ -3,12 +3,12 @@
 from typing import List
 
 import pluggy
-import questionary
 from sqlalchemy.orm.session import Session
 
 import moe
 from moe.core.config import Config
 from moe.core.library.album import Album
+from moe.plugins import add
 
 __all__ = ["Hooks"]
 
@@ -18,36 +18,21 @@ class Hooks:
 
     @staticmethod
     @moe.hookspec
-    def add_prompt_choice(prompt_choices: List[questionary.Choice]):
+    def add_prompt_choice(prompt_choices: List["add.PromptChoice"]):
         """Add a user input choice to the prompt.
 
         Args:
             prompt_choices: List of prompt choices. To add a prompt choice, simply
-                append it to this list. The prompt_choice is a ``questionary.Choice``
-                object.
-
-        Important:
-            Ensure to set the choice ``value`` to the function you want to be called
-            if the choice is selected by the user. The function should return the album
-            to be added to the library (or ``None`` if no album should be added) and
-            will be supplied the following keyword arguments:
-
-            ``config (Config)``: Moe config.
-            ``session (Session)``: Current db session.
-            ``old_album (Album)``: Old album with no changes applied.
-            ``new_album (Album)``: New album consisting of all the new changes.
+                append it to this list.
 
         Example:
             Inside your hook implementation::
 
                 prompt_choices.append(
-                    questionary.Choice(
-                        title="Abort", value=_abort_changes, shortcut_key="b"
+                    PromptChoice(
+                        title="Abort", shortcut_key="x", func=_abort_changes
                     )
                 )
-
-        For a full reference on ``questionary.Choice`` see:
-        https://questionary.readthedocs.io/en/stable/pages/api_reference.html#questionary.Choice
         """
 
     @staticmethod
@@ -77,6 +62,6 @@ class Hooks:
 @moe.hookimpl
 def add_hooks(plugin_manager: pluggy.manager.PluginManager):
     """Registers `add` hookspecs to Moe."""
-    from moe.plugins.add import Hooks  # noqa: WPS433, WPS442
+    from moe.plugins.add import Hooks  # noqa: WPS433, WPS442, WPS458
 
     plugin_manager.add_hookspecs(Hooks)

--- a/moe/plugins/musicbrainz.py
+++ b/moe/plugins/musicbrainz.py
@@ -17,7 +17,7 @@ import moe
 from moe.core.config import Config
 from moe.core.library.album import Album
 from moe.core.library.track import Track
-from moe.plugins.add import prompt as add_prompt
+from moe.plugins import add
 
 __all__: List[str] = []
 
@@ -44,13 +44,13 @@ RELEASE_INCLUDES = [  # noqa: WPS407
 
 
 @moe.hookimpl
-def add_prompt_choice(prompt_choices: List[questionary.Choice]):
+def add_prompt_choice(prompt_choices: List[add.PromptChoice]):
     """Adds the ``apply`` and ``abort`` prompt choices to the user prompt."""
     prompt_choices.append(
-        questionary.Choice(
+        add.PromptChoice(
             title="Enter Musicbrainz ID",
-            value=_enter_id,
             shortcut_key="m",
+            func=_enter_id,
         )
     )
 
@@ -174,4 +174,4 @@ def _enter_id(
     release = _get_release_by_id(mb_id)
     album = _create_album(release)
 
-    return add_prompt.run_prompt(config, session, old_album, album)
+    return add.run_prompt(config, session, old_album, album)


### PR DESCRIPTION
If we ever decide to use something other than questionary, abstracting the dependency will allow us to change the PromptChoice implementation without changing the API.