### PR TITLE
fix: write and move properly operate on all altered items

### DIFF
--- a/moe/plugins/edit.py
+++ b/moe/plugins/edit.py
@@ -11,7 +11,7 @@ import sqlalchemy
 import moe
 from moe.core import query
 from moe.core.config import Config
-from moe.core.library.track import LibItem
+from moe.core.library.lib_item import LibItem
 
 __all__ = ["EditError"]
 

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -168,8 +168,11 @@ class TestPreAdd:
 
 
 @pytest.mark.integration
-class TestPostArgs:
-    """Test integration with the ``post_args`` hook entry to the plugin."""
+class TestDBListener:
+    """Test registered database listeners.
+
+    Items are moved before they are flushed to the database.
+    """
 
     def test_edit_album(self, real_album, tmp_config, tmp_path):
         """Albums are moved to `library_path` after they are edited."""


### PR DESCRIPTION
Previously, we naively used `session.dirty` to inspect a session and determine if any items have been altered. This doesn't work since any flush prior to committing the db will also clean the session out. This change involves adding an sqlalchemy event listener hook to listen for db events so we can properly execute code anytime a new or changed item is introduced to the session.