### PR TITLE
fix(move): don't move items until they've been added to the db

### DIFF
--- a/alembic/versions/b5507b03f9e3_remove_extra_filename.py
+++ b/alembic/versions/b5507b03f9e3_remove_extra_filename.py
@@ -1,0 +1,28 @@
+"""Remove extra filename and rename `_path` to `path`.
+
+Revision ID: b5507b03f9e3
+Revises: 10f2c1aedd13
+Create Date: 2021-07-10 11:11:45.762003
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b5507b03f9e3"
+down_revision = "10f2c1aedd13"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("extras") as batch_op:
+        batch_op.alter_column("_path", new_column_name="path")
+        batch_op.drop_column("_filename")
+
+
+def downgrade():
+    with op.batch_alter_table("extras") as batch_op:
+        batch_op.alter_column("path", new_column_name="_path")
+        batch_op.add_column("extras", sa.Column("_filename", sa.String, nullable=False))

--- a/moe/core/library/album.py
+++ b/moe/core/library/album.py
@@ -70,7 +70,7 @@ class Album(LibItem, Base):
         collection_class=list,
     )
 
-    def __init__(  # noqa: WPS211
+    def __init__(
         self, artist: str, title: str, date: datetime.date, path: Path, **kwargs
     ):
         """Creates an album.
@@ -205,7 +205,7 @@ class Album(LibItem, Base):
         """Compares an Album by it's attributes."""
         if isinstance(other, Album):
             return (
-                self.artist == other.artist  # noqa: WPS222
+                self.artist == other.artist
                 and self.date == other.date
                 and self.mb_album_id == other.mb_album_id
                 and self.title == other.title

--- a/moe/core/library/lib_item.py
+++ b/moe/core/library/lib_item.py
@@ -1,4 +1,4 @@
-"""A LibItem in the database and any related logic."""
+"""Shared functionality between library albums, extras, and tracks."""
 
 from pathlib import Path
 
@@ -9,6 +9,11 @@ __all__ = ["LibItem"]
 
 class LibItem:
     """Abstract base class for library items i.e. Albums, Extras, and Tracks."""
+
+    @property
+    def path(self):
+        """A library item's filesystem path."""
+        raise NotImplementedError
 
 
 class PathType(sqlalchemy.types.TypeDecorator):

--- a/moe/core/library/track.py
+++ b/moe/core/library/track.py
@@ -49,7 +49,7 @@ __table_args__ = ()
 T = TypeVar("T", bound="Track")  # noqa: WPS111
 
 
-class Track(LibItem, Base):  # noqa: WPS230, WPS214
+class Track(LibItem, Base):
     """A single track.
 
     Attributes:
@@ -190,7 +190,7 @@ class Track(LibItem, Base):  # noqa: WPS230, WPS214
         """Compares a Track by it's attributes."""
         if isinstance(other, Track):
             return (
-                self.album_obj.artist == other.album_obj.artist  # noqa: WPS222
+                self.album_obj.artist == other.album_obj.artist
                 and self.album_obj.date == other.album_obj.date
                 and self.album_obj.title == other.album_obj.title
                 and self.artist == other.artist

--- a/moe/core/query.py
+++ b/moe/core/query.py
@@ -209,9 +209,7 @@ def _parse_term(term: str) -> Dict[str, str]:
     return match_dict
 
 
-def _create_expression(  # noqa: WPS231
-    term: Dict[str, str]
-) -> sqlalchemy.sql.elements.ClauseElement:
+def _create_expression(term: Dict[str, str]) -> sqlalchemy.sql.elements.ClauseElement:
     """Maps a user-given query term to a filter expression for the database query.
 
     Args:

--- a/moe/plugins/add/add.py
+++ b/moe/plugins/add/add.py
@@ -100,7 +100,7 @@ def _add_item(config: Config, session: Session, item_path: Path):
         config.plugin_manager.hook.pre_add(
             config=config, session=session, album=add_album
         )
-        session.merge(add_album)
+        add_album = session.merge(add_album)
 
 
 def _add_album(album_path: Path) -> Album:

--- a/moe/plugins/add/match.py
+++ b/moe/plugins/add/match.py
@@ -13,7 +13,7 @@ TrackCoord = Tuple[
 ]  # ((a.disc, a.track_num), (b.disc, b.track_num))
 
 
-def get_matching_tracks(  # noqa: WPS231
+def get_matching_tracks(
     album_a: Album, album_b: Album, match_threshold: int = 1
 ) -> List[TrackMatch]:
     """Returns a list of tuples of track match pairs.

--- a/moe/plugins/edit.py
+++ b/moe/plugins/edit.py
@@ -79,7 +79,7 @@ def _parse_args(
         raise SystemExit(1)
 
 
-def _edit_item(item: LibItem, term: str):  # noqa: WPS231, WPS238
+def _edit_item(item: LibItem, term: str):
     """Sets a LibItem's ``field`` to ``value``.
 
     Args:

--- a/moe/plugins/move.py
+++ b/moe/plugins/move.py
@@ -3,6 +3,7 @@
 import functools
 import logging
 import shutil
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -14,6 +15,7 @@ import moe
 from moe.core.config import Config
 from moe.core.library.album import Album
 from moe.core.library.extra import Extra
+from moe.core.library.lib_item import LibItem
 from moe.core.library.track import Track
 
 __all__: List[str] = []
@@ -29,13 +31,31 @@ def add_config_validator(settings: dynaconf.base.LazySettings):
     )
 
 
-def _move_session_items(
+@moe.hookimpl
+def register_db_listener(config: Config, session: Session):
+    """Sets item paths before they are flushed then moves them after a successful flush.
+
+    Args:
+        config: Moe config.
+        session: Current db session.
+    """
+    sqlalchemy.event.listen(
+        session,
+        "before_flush",
+        functools.partial(_set_sess_item_paths, config=config),
+    )
+    sqlalchemy.event.listen(session, "after_flush", _move_flushed_items)
+
+
+def _set_sess_item_paths(
     session: Session,
     flush_context: sqlalchemy.orm.UOWTransaction,
     instances: Optional[Any],
     config: Config,
 ):
-    """Moves any altered or new LibItem in a session.
+    """Sets the path of any new or altered items in the session.
+
+    Once the session is successfully flushed, the items will be moved on the filesystem.
 
     Args:
         session: Current db session.
@@ -45,35 +65,60 @@ def _move_session_items(
     """
     library_path = Path(config.settings.move.library_path).expanduser()
 
-    for item in session.new.union(session.dirty):
+    for item in session.dirty.union(session.new):
         if isinstance(item, Album):
-            album = item
+            item.path = _get_album_dir(item, library_path)
+            for track in item.tracks:
+                track.path = _get_track_path(track)
+            for extra in item.extras:
+                extra.path = _get_extra_path(extra)
         elif isinstance(item, Track):
-            album = item.album_obj
+            item.path = _get_track_path(item)
         elif isinstance(item, Extra):
-            album = item.album
-        else:
-            return
-
-        _move_album(album, library_path)
+            item.path = _get_extra_path(item)
 
 
-@moe.hookimpl
-def register_db_listener(config: Config, session: Session):
-    """Moves items prior to them being flushed to the database.
+def _move_flushed_items(session: Session, flush_context: sqlalchemy.orm.UOWTransaction):
+    """Moves altered or new items after they are successfully flushed to the db."""
+    # since moving an album involves moving all of its tracks and extras, it's possible
+    # to move a track or extra twice if both it and its album exist in ``items_to_move``
+    items_to_move = session.new.union(session.dirty)
+    albums_to_move = [item for item in items_to_move if isinstance(item, Album)]
+    for item in items_to_move:
+        if isinstance(item, Album):
+            _move_flushed_item(item)
+        elif isinstance(item, Extra) and item.album not in albums_to_move:
+            _move_flushed_item(item)
+        elif isinstance(item, Track) and item.album_obj not in albums_to_move:
+            _move_flushed_item(item)
 
-    Also, will undo any filyesystem changes in case of a session rollback.
 
-    Args:
-        config: Moe config.
-        session: Current db session.
-    """
-    sqlalchemy.event.listen(
-        session, "before_flush", functools.partial(_move_session_items, config=config)
-    )
+def _move_flushed_item(item: LibItem):
+    """Moves an item that has been flushed to the database."""
+    item_path_history = sqlalchemy.inspect(item).attrs.path.history
+    assert len(item_path_history.deleted) <= 1  # noqa: S101 # not sure if always True
+    try:
+        og_path = item_path_history.deleted[0]
+    except IndexError:
+        return
+
+    new_path = item.path  # the item's path is the path we need to move to
+
+    # Temporarily (will not change in the db) set the item's path to the original
+    # path so the move functions know where to find the files on the filesystem.
+    sqlalchemy.orm.attributes.set_committed_value(item, "path", og_path)
+
+    if isinstance(item, Album):
+        for track_or_extra in item.tracks + item.extras:  # type: ignore
+            _move_flushed_item(track_or_extra)
+        _move_album(item, new_path)
+    elif isinstance(item, Track):
+        _move_track(item, new_path)
+    elif isinstance(item, Extra):
+        _move_extra(item, new_path)
 
 
-@moe.hookimpl
+@moe.hookimpl(trylast=True)
 def pre_add(config: Config, session: Session, album: Album):
     """Copies and formats the path of an album prior to it being added."""
     library_path = Path(config.settings.move.library_path).expanduser()
@@ -101,28 +146,27 @@ def _get_album_dir(album: Album, root_dir: Path) -> Path:
     return root_dir / album_dir_name
 
 
-def _get_extra_path(extra: Extra, album_dir: Path) -> Path:
-    """Returns a formatted track path under ``album_dir``."""
-    return album_dir / extra.path.name
+def _get_extra_path(extra: Extra) -> Path:
+    """Returns a formatted extra path."""
+    return extra.album.path / extra.path.name
 
 
-def _get_track_path(track: Track, album_dir: Path) -> Path:
-    """Returns a formatted track path under ``album_dir``.
+def _get_track_path(track: Track) -> Path:
+    """Returns a formatted track path.
 
     The track path should contain, at a minimum, the track number and
     disc (if more than one) to ensure uniqueness.
 
     Args:
         track: Track used to format the path.
-        album_dir: Directory to place the album directory under.
 
     Returns:
-        Formatted album directory under ``root_dir``.
+        Formatted track path.
     """
     disc_dir_name = ""
     if track.disc_total > 1:
         disc_dir_name = f"Disc {track.disc:02}"
-    disc_dir = album_dir / disc_dir_name
+    disc_dir = track.album_obj.path / disc_dir_name
 
     track_filename = f"{track.track_num:02} - {track.title}.{track.file_ext}"
     return disc_dir / track_filename
@@ -130,150 +174,155 @@ def _get_track_path(track: Track, album_dir: Path) -> Path:
 
 ########################################################################################
 # Copy
-# ####
-#
-# When copying an item, operate at the album-level with `_copy_album()`.
 ########################################################################################
-def _copy_album(album: Album, root_dir: Path):
+def _copy_album(album: Album, dest: Path):
     """Copies an album to a formatted dir under ``root_dir``.
 
-    Overwrites any existing files.
+    Overwrites any existing files. Will create ``dest`` if it does not already exist.
+    Copying an album will also copy all of it's tracks and extras.
 
     Args:
         album: Album to copy
-        root_dir: Root directory to copy the album to.
+        dest: Destination to copy the album to.
     """
-    album_dir = _get_album_dir(album, root_dir)
+    if album.path == dest:
+        return
 
-    album_dir.mkdir(parents=True, exist_ok=True)
+    log.info(f"Copying album from '{album.path}' to '{dest}'.")
+    album.path = dest
+
+    album.path.mkdir(parents=True, exist_ok=True)
 
     for track in album.tracks:
-        _copy_track(track, album_dir)
+        _copy_track(track)
 
     for extra in album.extras:
-        _copy_extra(extra, album_dir)
-
-    album.path = album_dir
+        _copy_extra(extra)
 
 
-def _copy_track(track: Track, album_dir: Path):
-    """Copies a track to a formatted destination under ``album_dir``.
+def _copy_track(track: Track, dest: Path = None):
+    """Copies a track to a given or generated destination.
 
     Overwrites any existing files.
 
     Args:
         track: Track to copy.
-        album_dir: Album directory destination.
+        dest: Destination to copy the extra to. If not given, the destination will be
+            generated by the track's attributes.
     """
-    track_dest = _get_track_path(track, album_dir)
+    if not dest:
+        dest = _get_track_path(track)
 
-    if track_dest == track.path:
+    if dest == track.path:
         return
 
-    log.info(f"Copying track '{track.path}' to '{track_dest}'.")
-    track_dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(track.path, track_dest)
+    log.info(f"Copying track from '{track.path}' to '{dest}'.")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(track.path, dest)
 
-    track.path = track_dest
+    track.path = dest
 
 
-def _copy_extra(extra: Extra, album_dir: Path):
-    """Copies an extra to a formatted destination under ``album_dir``.
+def _copy_extra(extra: Extra, dest: Path = None):
+    """Copies an extra to a given or generated destination.
 
     Overwrites any existing files.
 
     Args:
         extra: Extra to copy.
-        album_dir: Album directory to copy the extra to.
+        dest: Destination to copy the extra to. If not given, the destination will be
+            generated by the extra's attributes.
     """
-    extra_dest = _get_extra_path(extra, album_dir)
+    if not dest:
+        dest = _get_extra_path(extra)
 
-    if extra_dest == extra.path:
+    if dest == extra.path:
         return
 
-    log.info(f"Copying extra '{extra}' to '{extra_dest}'.")
-    extra_dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(extra.path, extra_dest)
+    log.info(f"Copying extra from '{extra.path}' to '{dest}'.")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(extra.path, dest)
 
-    extra.path = extra_dest
+    extra.path = dest
 
 
 ########################################################################################
 # Move
-# ####
-#
-# When moving an item, operate at the album-level with `_move_album()`.
 ########################################################################################
-def _move_album(album: Album, root_dir: Path):
-    """Moves an album to a formatted dir under ``root_dir``.
+def _move_album(album: Album, dest: Path):
+    """Moves an album to a given destination.
 
-    Overwrites any existing files.
+    Overwrites any existing files. Will create ``dest`` if it does not already exist.
+    Moving an album will also move all of it's tracks and extras.
 
     Args:
-        album: Album to copy
-        root_dir: Root directory to copy the album to.
+        album: Album to move.
+        dest: Destination to move the album to.
     """
-    album_dir = _get_album_dir(album, root_dir)
+    if album.path == dest:
+        return
 
-    album_dir.mkdir(parents=True, exist_ok=True)
+    log.info(f"Moving album from '{album.path}' to '{dest}'.")
+    old_album_dir = album.path
+    album.path = dest
+    album.path.mkdir(parents=True, exist_ok=True)
 
     for track in album.tracks:
-        _move_track(track, album_dir)
+        _move_track(track)
 
     for extra in album.extras:
-        _move_extra(extra, album_dir)
+        _move_extra(extra)
 
     # remove any empty leftover directories
-    for old_path in album.path.rglob("*"):
-        try:
+    for old_path in old_album_dir.rglob("*"):
+        with suppress(OSError):
             old_path.rmdir()
-        except OSError:
-            pass  # noqa: WPS420
-    try:
-        album.path.rmdir()
-    except OSError:
-        pass  # noqa: WPS420
-
-    album.path = album_dir
+    with suppress(OSError):
+        old_album_dir.rmdir()
 
 
-def _move_track(track: Track, album_dir: Path):
-    """Moves a track to a formatted destination under ``album_dir``.
+def _move_track(track: Track, dest: Path = None):
+    """Moves a track to a given or generated destination.
 
     Overwrites any existing files.
 
     Args:
-        track: Track to copy.
-        album_dir: Album directory destination.
+        track: Track to move.
+        dest: Destination to move the track to. If not given, the destination will be
+            generated by the track's attributes.
     """
-    track_dest = _get_track_path(track, album_dir)
+    if not dest:
+        dest = _get_track_path(track)
 
-    if track_dest == track.path:
+    if dest == track.path:
         return
 
-    log.info(f"Moving track '{track.path}' to '{track_dest}'.")
-    track_dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(track.path, track_dest)
+    log.info(f"Moving track from '{track.path}' to '{dest}'.")
+    dest.parent.mkdir(parents=True, exist_ok=True)
 
-    track.path = track_dest
+    track.path.replace(dest)
+
+    track.path = dest
 
 
-def _move_extra(extra: Extra, album_dir: Path):
-    """Moves an extra to a formatted destination under ``album_dir``.
+def _move_extra(extra: Extra, dest: Path = None):
+    """Moves an extra to a given or generated destination.
 
     Overwrites any existing files.
 
     Args:
-        extra: Extra to copy.
-        album_dir: Album directory to copy the extra to.
+        extra: Extra to move.
+        dest: Destination to move the extra to. If not given, the destination will be
+            generated by the extra's attributes.
     """
-    extra_dest = _get_extra_path(extra, album_dir)
+    if not dest:
+        dest = _get_extra_path(extra)
 
-    if extra_dest == extra.path:
+    if dest == extra.path:
+        log.debug(f"dest: {dest}")
         return
 
-    log.info(f"Copying extra '{extra}' to '{extra_dest}'.")
-    extra_dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.move(extra.path, extra_dest)
-
-    extra.path = extra_dest
+    log.info(f"Moving extra from '{extra.path}' to '{dest}'.")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    extra.path.replace(dest)
+    extra.path = dest

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,13 +22,7 @@ ignore =
     E266,    # too many leading '#' for block comment
     W503,    # line break before binary operator (black conflict)
     WPS110,  # "value" is common to refer to a tag/field's value
-    WPS201,  # too many imports (type hints artificially increase the # of imports)
-    WPS202,  # too many module members (modules should not be separated based of members)
-    WPS210,  # too many local vars (varabless should be used to increase code clarity)
-    WPS221,  # per-line complexity checks
-    WPS226,  # string constant over-use
-    WPS232,  # module complexity
-    WPS237,  # too complex f strings (limits the power/purpose of them)
+    WPS2,    # complexity checks
     WPS301,  # allow use of dotted raw imports
     WPS305,  # prohibit use of f strings
     WPS306,  # requires all classes to have base classes
@@ -50,9 +44,8 @@ per-file-ignores =
    # D1: database migrations don't need docstrings
    # I: isort errors tend to misinterpret alembic as a local package
    # WPS102: module/file names aren't standard
-   # WPS2: don't care about comlexity in migrations
    # WPS437: alembic can use protected attributes
-   alembic/versions/*.py:D1,I,WPS102,WPS2,WPS437
+   alembic/versions/*.py:D1,I,WPS102,WPS437
    # DAR101: pytest uses fixtures as arguments, documenting each use is unnecessary
    # DAR102: factory arguments with fixtures can be weird
    # S101: pytest uses assert statements
@@ -71,11 +64,9 @@ per-file-ignores =
    # WPS347: allow * imports (used for packaging in some cases)
    # WPS440: * causes block overlaps
    */__init__.py:F401,F403,WPS300,WPS347,WPS440
-   # WPS214: libary classes have as many methods as necessary
-   # WPS226: empty string is often used for sql default values
    # WPS437: library models cross-talk `_id` frequently
    # WPS601: shadowed class attributes are used with sqlalchemy
-   moe/core/library/*.py:WPS214,WPS226,WPS437,WPS601
+   moe/core/library/*.py:WPS437,WPS601
 
 [darglint]
 docstring_style = google

--- a/tests/test_add/test_add.py
+++ b/tests/test_add/test_add.py
@@ -171,7 +171,7 @@ class TestAddItemFromDir:
             track.title = "new_album"
 
         for extra_num, extra in enumerate(new_album.extras):
-            extra.filename = f"{extra_num} new_album"
+            extra.path = Path(f"{extra_num}.txt")
 
         assert new_album.mb_album_id != existing_album.mb_album_id
         assert new_album.tracks != existing_album.tracks

--- a/tests/test_add/test_match.py
+++ b/tests/test_add/test_match.py
@@ -48,8 +48,8 @@ class TestGetMatchingTracks:
 
     def test_high_threshold(self, mock_track_factory):
         """A zero threshold should always return a match."""
-        track1 = mock_track_factory()
-        track2 = mock_track_factory()
+        track1 = mock_track_factory(track_num=1)
+        track2 = mock_track_factory(track_num=2)
         assert track1.track_num != track2.track_num
 
         track_matches = add.match.get_matching_tracks(

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -47,29 +47,6 @@ class TestParseArgs:
 
         assert mock_track.album == "new title"
 
-    def test_extra(self, real_album):
-        """We can edit an Extra's filename.
-
-        Editing an Extra's filename should also rename the file.
-        """
-        new_filename = "dumb_log.txt"
-        args = argparse.Namespace(
-            fv_terms=[f"filename={new_filename}"], query="", album=False, extra=True
-        )
-
-        extra = real_album.extras.pop()
-        old_path = extra.path
-        with patch("moe.core.query.query", return_value=[extra]) as mock_query:
-            mock_session = Mock()
-
-            edit._parse_args(config=Mock(), session=mock_session, args=args)
-
-            mock_query.assert_called_once_with("", mock_session, query_type="extra")
-
-        assert extra.filename == new_filename
-        assert extra.path.is_file()
-        assert not old_path.is_file()
-
     def test_int_field(self, mock_track):
         """We can edit integer fields."""
         args = argparse.Namespace(


### PR DESCRIPTION
Previously, items were moved prior to them being successfully added to the database. The issue with this is if an error occurs while adding to the database, but you've already moved the item. This would result in a discrepancy between the file path in the database and the actual file path on the filesystem.