### PR TITLE
fix(move): album copies to proper directory on add

### DIFF
--- a/moe/plugins/move.py
+++ b/moe/plugins/move.py
@@ -123,7 +123,7 @@ def pre_add(config: Config, session: Session, album: Album):
     """Copies and formats the path of an album prior to it being added."""
     library_path = Path(config.settings.move.library_path).expanduser()
 
-    _copy_album(album, library_path)
+    _copy_album(album, _get_album_dir(album, library_path))
 
 
 ########################################################################################
@@ -176,7 +176,7 @@ def _get_track_path(track: Track) -> Path:
 # Copy
 ########################################################################################
 def _copy_album(album: Album, dest: Path):
-    """Copies an album to a formatted dir under ``root_dir``.
+    """Copies an album to a given destination.
 
     Overwrites any existing files. Will create ``dest`` if it does not already exist.
     Copying an album will also copy all of it's tracks and extras.

--- a/tests/test_move.py
+++ b/tests/test_move.py
@@ -160,10 +160,14 @@ class TestPreAdd:
         with session_scope() as session:
             album = session.query(Album).one()
 
+            assert tmp_path in album.path.parents
+            assert album.path.exists()
             for new_track in album.tracks:
                 assert tmp_path in new_track.path.parents
+                assert new_track.path.exists()
             for new_extra in album.extras:
                 assert tmp_path in new_extra.path.parents
+                assert new_extra.path.exists()
 
         for og_path in og_paths:
             assert og_path.exists()
@@ -203,10 +207,13 @@ class TestDBListener:
         with session_scope() as session:
             album = session.query(Album).one()
 
+            assert album.path.exists()
             for new_track in album.tracks:
                 assert tmp_path in new_track.path.parents
+                assert new_track.path.exists()
             for new_extra in album.extras:
                 assert tmp_path in new_extra.path.parents
+                assert new_extra.path.exists()
 
         for og_path in og_paths:
             assert not og_path.exists()
@@ -231,6 +238,7 @@ class TestDBListener:
         with session_scope() as session:
             track = session.query(Track).one()
 
+            assert track.path.exists()
             assert new_title in track.path.name
 
         assert not og_path.exists()


### PR DESCRIPTION
Upon adding an album, it was getting copied to the root library directory, but the album's path in the library was getting saved as the proper album directory, resulting in a disconnect between the database path and the actual library path.