### PR TITLE
refactor(info): album info now only prints album attributes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,9 @@ def mock_extra_factory() -> Callable[[], Extra]:
         Unique Extra object.
     """
 
+    def mock_lt(self, other):
+        return self.name < other.name
+
     def _mock_extra(album: Album = None, year: int = 1996):
         if not album:
             album = Album(
@@ -163,6 +166,8 @@ def mock_extra_factory() -> Callable[[], Extra]:
             )
 
         mock_path = MagicMock()
+
+        mock_path.__lt__ = mock_lt
         mock_path.name = f"{random.randint(1, 1000)}.txt"
         return Extra(mock_path, album)
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,8 +1,6 @@
 """Tests the ``info`` plugin."""
 
 import argparse
-import re
-import types
 from unittest.mock import Mock, patch
 
 import pytest
@@ -72,86 +70,6 @@ class TestParseArgs:
             info._parse_args(config=Mock(), session=Mock(), args=args)
 
         assert error.value.code != 0
-
-
-class TestFmtInfos:
-    """Test how multiple items are represented together."""
-
-    def test_newline_between(self, capsys, mock_track_factory):
-        """Items should be *separated* by newlines.
-
-        There should not be a newline after the last item.
-        """
-        track1 = mock_track_factory()
-        track2 = mock_track_factory()
-
-        track_infos = info._fmt_infos([track1, track2])
-
-        sep_infos = track_infos.split("\n\n")
-
-        assert len(sep_infos) == 2
-        assert sep_infos[0].strip() == info._fmt_info(track1).strip()
-        assert sep_infos[1].strip() == info._fmt_info(track2).strip()
-
-
-class TestFmtInfo:
-    """Test how an individual item is represented for our plugin."""
-
-    def test_format(self, capsys, mock_track):
-        """Should format as attribute: value. One pair per line."""
-        mock_track.path.__str__.return_value = "test path"
-
-        assert re.match(r"(\w+:\s.+\n)+", info._fmt_info(mock_track))
-
-
-class TestTrackDict:
-    """Test dict representation of a Track."""
-
-    def test_no_private_attributes(self, mock_track):
-        """Private attributes should not be included."""
-        private_re = "^_.*"
-        for key in info._item_dict(mock_track).keys():
-            assert not re.match(private_re, key)
-
-    def test_no_methods(self, mock_track):
-        """Methods should not be included."""
-        for key in info._item_dict(mock_track).keys():
-            assert not isinstance(getattr(mock_track, key), types.MethodType)
-
-    def test_no_sqlalchemy_attrs(self, mock_track):
-        """Sqlalchemy attributes are not relevant and should not be included."""
-        assert "metadata" not in info._item_dict(mock_track).keys()
-        assert "registry" not in info._item_dict(mock_track).keys()
-
-
-class TestAlbumDict:
-    """Test dict representation of an Album."""
-
-    def test_second_track_attribute_dne(self, mock_track_factory):
-        """If varying existence of fields between tracks, set field to Various.
-
-        For example, if track 1 has a year, but track 2 doesn't. The album should
-        display `year: Various`.
-        """
-        track1 = mock_track_factory()
-        track2 = mock_track_factory()
-
-        track1.artist = "don't show this"
-        track2.artist = ""
-        track1.album_obj = track2.album_obj
-
-        assert info._item_dict(track1.album_obj)["artist"] == "Various"
-
-    def test_second_track_attribute_different(self, mock_track_factory):
-        """If varying field values between tracks, set field to Various."""
-        track1 = mock_track_factory()
-        track2 = mock_track_factory()
-
-        track1.artist = "don't show this"
-        track2.artist = "different"
-        track1.album_obj = track2.album_obj
-
-        assert info._item_dict(track1.album_obj)["artist"] == "Various"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
If it seems more useful to print certain track information with the album, I may start just adding them on a case-by-case basis or including an optional way to also print the aggregate track information alongside the album.