### PR TITLE
refactor: abstract sqlalchemy orm events into new hook specifications

### DIFF
--- a/moe/cli.py
+++ b/moe/cli.py
@@ -32,10 +32,8 @@ class Hooks:
         """Add a sub-command to Moe's CLI.
 
         Args:
-            cmd_parsers: Contains all the sub-command parsers.
-
-        Note:
-            The sub-command should be added as an argparse parser to cmd_parsers.
+            cmd_parsers: Contains all the sub-command parsers. The new sub-command
+                should be added as an argparse parser to `cmd_parsers`.
 
         Example:
             Inside your hook implementation::
@@ -44,7 +42,7 @@ class Hooks:
                 my_parser.add_argument('bar', type=int)
                 my_parser.set_defaults(func=my_function)
 
-        Note:
+        Important:
             To specify a function to run when your command is passed, you need to
             define the ``func`` key using ``set_defaults`` as shown above.
             The function will be called like::
@@ -54,6 +52,20 @@ class Hooks:
                     session: sqlalchemy.orm.session.Session,  # database session
                     args: argparse.Namespace,  # parsed commandline arguments
                 )
+
+        Note:
+            If your command utilizes a `query`, you can specify ``query_parser`` as
+            a parent parser::
+
+                edit_parser = cmd_parsers.add_parser(
+                    "list",
+                    description="Lists music in the library.",
+                    parents=[query.query_parser],
+                )
+
+        See Also:
+            `The python documentation for adding sub-parsers.
+            <https://docs.python.org/3/library/argparse.html#sub-commands>`_
         """
 
     @staticmethod
@@ -67,7 +79,7 @@ class Hooks:
             items: Any new or changed items in the current session. The items and
                 their changes have not yet been committed to the library.
 
-        .. seealso::
+        See Also:
             The :meth:`process_new_items` hook if you wish to process any items after
             any final edits have been made and they have been successfully added to
             the library.
@@ -84,7 +96,7 @@ class Hooks:
             items: Any new or changed items that have been successfully added to the
                 library during the current session.
 
-        .. seealso::
+        See Also:
             The :meth:`edit_new_items` hook if you wish to edit the items.
         """
 

--- a/moe/plugins/edit.py
+++ b/moe/plugins/edit.py
@@ -35,17 +35,17 @@ def add_command(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     https://mrmoe.readthedocs.io/en/latest/plugins/edit.html
     """
 
-    add_parser = cmd_parsers.add_parser(
+    edit_parser = cmd_parsers.add_parser(
         "edit",
         description="Edits music in the library.",
         help="edit music in the library",
         parents=[query.query_parser],
         epilog=epilog_help,
     )
-    add_parser.add_argument(
+    edit_parser.add_argument(
         "fv_terms", metavar="FIELD=VALUE", nargs="+", help="set FIELD to VALUE"
     )
-    add_parser.set_defaults(func=_parse_args)
+    edit_parser.set_defaults(func=_parse_args)
 
 
 def _parse_args(

--- a/moe/plugins/info.py
+++ b/moe/plugins/info.py
@@ -24,13 +24,13 @@ __all__: List[str] = []
 @moe.hookimpl
 def add_command(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     """Adds the ``info`` command to Moe's CLI."""
-    add_parser = cmd_parsers.add_parser(
+    info_parser = cmd_parsers.add_parser(
         "info",
         description="Prints information about music in the library.",
         help="print info for music in the library",
         parents=[query.query_parser],
     )
-    add_parser.set_defaults(func=_parse_args)
+    info_parser.set_defaults(func=_parse_args)
 
 
 def _parse_args(

--- a/moe/plugins/list.py
+++ b/moe/plugins/list.py
@@ -15,14 +15,14 @@ __all__: List[str] = []
 @moe.hookimpl
 def add_command(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     """Adds the ``list`` command to Moe's CLI."""
-    add_parser = cmd_parsers.add_parser(
+    ls_parser = cmd_parsers.add_parser(
         "list",
         aliases=["ls"],
         description="Lists music in the library.",
         help="list music in the library",
         parents=[query.query_parser],
     )
-    add_parser.set_defaults(func=_parse_args)
+    ls_parser.set_defaults(func=_parse_args)
 
 
 def _parse_args(

--- a/moe/plugins/remove.py
+++ b/moe/plugins/remove.py
@@ -18,14 +18,14 @@ log = logging.getLogger("moe.remove")
 @moe.hookimpl
 def add_command(cmd_parsers: argparse._SubParsersAction):  # noqa: WPS437
     """Adds the ``remove`` command to Moe's CLI."""
-    add_parser = cmd_parsers.add_parser(
+    rm_parser = cmd_parsers.add_parser(
         "remove",
         aliases=["rm"],
         description="Removes music from the library.",
         help="remove music from the library",
         parents=[query.query_parser],
     )
-    add_parser.set_defaults(func=_parse_args)
+    rm_parser.set_defaults(func=_parse_args)
 
 
 def _parse_args(


### PR DESCRIPTION
Primarily, this is to allow us to somewhat control the ordering of hook implementations using `trylast` and `tryfirst`. Mostly, I envisioned this being an issue if attempting to change an item's path before another plugin decided to change that item's title, for example. This is why the `move` plugin is set to `trylast`.

Also, this abstracts some unneeded complexity for plugins when dealing directly with sqlalchemy orm events.